### PR TITLE
Add product name field and update services

### DIFF
--- a/src/main/java/com/tienda/pedidos/producto/Producto.java
+++ b/src/main/java/com/tienda/pedidos/producto/Producto.java
@@ -9,14 +9,16 @@ import java.math.BigDecimal;
 public class Producto {
     @Id
     private String sku;
+    private String nombre;
     private BigDecimal precio;
     private int stock;
 
     public Producto() {
     }
 
-    public Producto(String sku, BigDecimal precio, int stockInicial) {
+    public Producto(String sku, String nombre, BigDecimal precio, int stockInicial) {
         this.sku = sku;
+        this.nombre = nombre;
         this.precio = precio;
         this.stock = stockInicial;
     }
@@ -27,6 +29,14 @@ public class Producto {
 
     public void setSku(String sku) {
         this.sku = sku;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
     }
 
     public BigDecimal getPrecio() {
@@ -49,6 +59,7 @@ public class Producto {
     public String toString() {
         return "producto{" +
                 "sku='" + sku + '\'' +
+                ", nombre='" + nombre + '\'' +
                 ", precio=" + precio +
                 ", stockInicial=" + stock +
                 '}';

--- a/src/main/java/com/tienda/pedidos/producto/ProductoCommandService.java
+++ b/src/main/java/com/tienda/pedidos/producto/ProductoCommandService.java
@@ -2,6 +2,8 @@ package com.tienda.pedidos.producto;
 
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
+
 @Service
 public class ProductoCommandService {
 
@@ -11,7 +13,8 @@ public class ProductoCommandService {
         this.productoRepository = productoRepository;
     }
 
-    public Producto crearProducto(Producto producto) {
+    public Producto crearProducto(String sku, String nombre, BigDecimal precio, int stock) {
+        Producto producto = new Producto(sku, nombre, precio, stock);
         return productoRepository.save(producto);
     }
 

--- a/src/main/java/com/tienda/pedidos/producto/ProductoResource.java
+++ b/src/main/java/com/tienda/pedidos/producto/ProductoResource.java
@@ -19,7 +19,12 @@ public class ProductoResource {
 
     @PostMapping(value = "/products")
     public Producto crearProducto(@RequestBody Producto producto){
-        return productoCommandService.crearProducto(producto);
+        return productoCommandService.crearProducto(
+                producto.getSku(),
+                producto.getNombre(),
+                producto.getPrecio(),
+                producto.getStock()
+        );
     }
 
 

--- a/src/test/java/com/tienda/pedidos/producto/ProductoCommandServiceTest.java
+++ b/src/test/java/com/tienda/pedidos/producto/ProductoCommandServiceTest.java
@@ -1,0 +1,34 @@
+package com.tienda.pedidos.producto;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+class ProductoCommandServiceTest {
+
+    @Autowired
+    private ProductoCommandService productoCommandService;
+
+    @Autowired
+    private ProductoRepository productoRepository;
+
+    @Test
+    void crearProductoPersisteNombre() {
+        String sku = "sku-test";
+        String nombre = "Producto de prueba";
+        BigDecimal precio = new BigDecimal("10.00");
+        int stock = 5;
+
+        productoCommandService.crearProducto(sku, nombre, precio, stock);
+        Producto productoGuardado = productoRepository.findById(sku).orElseThrow();
+
+        assertEquals(nombre, productoGuardado.getNombre());
+        assertEquals(precio, productoGuardado.getPrecio());
+        assertEquals(stock, productoGuardado.getStock());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `nombre` property to `Producto` entity with constructors, accessors, and toString update
- Update command service and REST resource to handle `nombre`
- Add test ensuring `nombre` is persisted

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4560caa0883279f794e2d9a7be36f