### PR TITLE
Add custom product exceptions and rename stock method

### DIFF
--- a/src/main/java/com/tienda/pedidos/pedido/comandos/ProcesarPedidoCommand.java
+++ b/src/main/java/com/tienda/pedidos/pedido/comandos/ProcesarPedidoCommand.java
@@ -35,7 +35,7 @@ public class ProcesarPedidoCommand extends Comando {
         ArrayList<ProductoPedido> productos = pedido.getProductos();
 
         for (ProductoPedido productoPedido : productos){
-            productoCommandService.discreaseStock(productoPedido.getProducto().getSku(), productoPedido.getCantidad());
+            productoCommandService.decreaseStock(productoPedido.getProducto().getSku(), productoPedido.getCantidad());
         }
 
         boolean permiso = this.cobroService.process(pedido);

--- a/src/main/java/com/tienda/pedidos/producto/OutOfStockException.java
+++ b/src/main/java/com/tienda/pedidos/producto/OutOfStockException.java
@@ -1,0 +1,11 @@
+package com.tienda.pedidos.producto;
+
+public class OutOfStockException extends RuntimeException {
+    public OutOfStockException() {
+        super("Stock insuficiente");
+    }
+
+    public OutOfStockException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/tienda/pedidos/producto/ProductoCommandService.java
+++ b/src/main/java/com/tienda/pedidos/producto/ProductoCommandService.java
@@ -15,12 +15,12 @@ public class ProductoCommandService {
         return productoRepository.save(producto);
     }
 
-    public synchronized Producto discreaseStock(String id, int cantidad) {
+    public synchronized Producto decreaseStock(String id, int cantidad) {
         Producto producto = productoRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Producto no encontrado"));
+                .orElseThrow(ProductoNotFoundException::new);
 
         if (producto.getStock() < cantidad) {
-            throw new RuntimeException("Stock insuficiente");
+            throw new OutOfStockException();
         }
 
         producto.setStock(producto.getStock() - cantidad);
@@ -29,8 +29,7 @@ public class ProductoCommandService {
 
     public synchronized Producto increaseStock(String id, int cantidad) {
         Producto producto = productoRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Producto no encontrado"));
-
+                .orElseThrow(ProductoNotFoundException::new);
 
         producto.setStock(producto.getStock() + cantidad);
         return productoRepository.save(producto);

--- a/src/main/java/com/tienda/pedidos/producto/ProductoNotFoundException.java
+++ b/src/main/java/com/tienda/pedidos/producto/ProductoNotFoundException.java
@@ -1,0 +1,11 @@
+package com.tienda.pedidos.producto;
+
+public class ProductoNotFoundException extends RuntimeException {
+    public ProductoNotFoundException() {
+        super("Producto no encontrado");
+    }
+
+    public ProductoNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/tienda/pedidos/producto/ProductoQueryService.java
+++ b/src/main/java/com/tienda/pedidos/producto/ProductoQueryService.java
@@ -12,7 +12,7 @@ public class ProductoQueryService {
     }
 
     public Producto getProductoById(String id) {
-        return productoRepository.findById(id).orElseThrow(() -> new RuntimeException("Producto no encontrado"));
+        return productoRepository.findById(id).orElseThrow(ProductoNotFoundException::new);
     }
 
 }


### PR DESCRIPTION
## Summary
- rename `discreaseStock` to `decreaseStock` and use custom exceptions when adjusting product inventory
- add `OutOfStockException` and `ProductoNotFoundException` for clearer errors
- update services and commands to throw the new exceptions instead of `RuntimeException`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b456208b108327a283354bbdfdcc5b