### PR TITLE
Add date range support for daily sales report

### DIFF
--- a/src/main/java/com/tienda/pedidos/consultas/consultasResources.java
+++ b/src/main/java/com/tienda/pedidos/consultas/consultasResources.java
@@ -36,7 +36,14 @@ public class consultasResources {
     }
 
     @RequestMapping(value = "/reports/daily-sales")
-    public ArrayList<Pedido> pedidosByFecha(@RequestParam Date fecha){
-        return (ArrayList<Pedido>) pedidoQueryService.getPedidosByFecha(fecha);
+    public ArrayList<Pedido> pedidosByFecha(@RequestParam(required = false) Date from,
+                                           @RequestParam(required = false) Date to,
+                                           @RequestParam(required = false) Date fecha) {
+        if (from != null && to != null) {
+            return (ArrayList<Pedido>) pedidoQueryService.getPedidosByFechaBetween(from, to);
+        } else if (fecha != null) {
+            return (ArrayList<Pedido>) pedidoQueryService.getPedidosByFecha(fecha);
+        }
+        return new ArrayList<>();
     }
 }

--- a/src/main/java/com/tienda/pedidos/pedido/PedidoQueryService.java
+++ b/src/main/java/com/tienda/pedidos/pedido/PedidoQueryService.java
@@ -4,6 +4,7 @@ package com.tienda.pedidos.pedido;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.Date;
 
 @Service
 public class PedidoQueryService {
@@ -22,7 +23,11 @@ public class PedidoQueryService {
         return pedidoRepository.findByEstado(estado);
     }
 
-    public ArrayList<Pedido> getPedidosByFecha(java.util.Date fecha) {
-        return pedidoRepository.findByfecha(fecha);
+    public ArrayList<Pedido> getPedidosByFecha(Date fecha) {
+        return pedidoRepository.findByFecha(fecha);
+    }
+
+    public ArrayList<Pedido> getPedidosByFechaBetween(Date from, Date to) {
+        return pedidoRepository.findByFechaBetween(from, to);
     }
 }

--- a/src/main/java/com/tienda/pedidos/pedido/PedidoRepository.java
+++ b/src/main/java/com/tienda/pedidos/pedido/PedidoRepository.java
@@ -9,5 +9,7 @@ public interface PedidoRepository extends JpaRepository<Pedido, Integer> {
 
     public ArrayList<Pedido> findByEstado(Estado estado);
 
-    public ArrayList<Pedido> findByfecha(Date fecha);
+    public ArrayList<Pedido> findByFecha(Date fecha);
+
+    public ArrayList<Pedido> findByFechaBetween(Date from, Date to);
 }


### PR DESCRIPTION
## Summary
- Rename `findByfecha` to `findByFecha` for proper camel case
- Add `findByFechaBetween` repository method and service wrapper
- Extend daily sales endpoint to accept optional `from`/`to` parameters for date ranges

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `./mvnw -q test` *(fails: Failed to fetch dependency due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68b45643c6f8832798b3a856606fe58a