### PR TITLE
Refactor PedidoResource for constructor injection and idempotence

### DIFF
--- a/src/main/java/com/tienda/pedidos/pedido/PedidoResource.java
+++ b/src/main/java/com/tienda/pedidos/pedido/PedidoResource.java
@@ -1,46 +1,54 @@
 package com.tienda.pedidos.pedido;
 
 import com.tienda.pedidos.cobro.CobroService;
+import com.tienda.pedidos.pedido.Estado;
 import com.tienda.pedidos.pedido.comandos.ProcesarPedidoCommand;
 import com.tienda.pedidos.producto.ProductoCommandService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class PedidoResource {
 
-    private PedidoCommandService pedidoCommandService;
-    private PedidoQueryService pedidoQueryService;
+    private final PedidoCommandService pedidoCommandService;
+    private final PedidoQueryService pedidoQueryService;
 
-    private ProductoCommandService productoCommandService;
+    private final ProductoCommandService productoCommandService;
 
-    private CobroService cobroService;
+    private final CobroService cobroService;
 
 
-    public PedidoResource(PedidoCommandService pedidoCommandService, PedidoQueryService pedidoQueryService) {
+    public PedidoResource(PedidoCommandService pedidoCommandService, PedidoQueryService pedidoQueryService,
+                          ProductoCommandService productoCommandService, CobroService cobroService) {
         this.pedidoCommandService = pedidoCommandService;
         this.pedidoQueryService = pedidoQueryService;
+        this.productoCommandService = productoCommandService;
+        this.cobroService = cobroService;
     }
 
-    @RequestMapping(value = "/orders")
+    @PostMapping("/orders")
     public Pedido crearPedido(@RequestBody Pedido pedido){
         return pedidoCommandService.crearPedido(pedido);
     }
 
 
-    @RequestMapping(value = "/order")
-    public Pedido obtenerPedido(@RequestParam int id){
+    @GetMapping("/orders/{id}")
+    public Pedido obtenerPedido(@PathVariable int id){
         return pedidoQueryService.getPedidoById(id);
     }
 
-    @RequestMapping(value = "/processOrder")
-    public Pedido procesarPedido(int id){
+    @PostMapping("/orders/{id}/process")
+    public Pedido procesarPedido(@PathVariable int id){
         Pedido pedido = pedidoCommandService.getById(id);
         if (pedido == null) {
             System.out.println("Pedido con ID " + id + " no encontrado.");
             throw new RuntimeException("Pedido con ID " + id + " no encontrado.");
+        }
+        if (pedido.getEstado() != Estado.CREATED) {
+            return pedido;
         }
         ProcesarPedidoCommand procesarPedidoCommand = new ProcesarPedidoCommand(pedido, productoCommandService,
                 pedidoCommandService, cobroService);


### PR DESCRIPTION
## Summary
- Inject ProductoCommandService and CobroService via constructor
- Replace generic RequestMapping annotations with explicit PostMapping and GetMapping endpoints
- Validate order state before processing to ensure idempotence

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b456b707688327a6f8d3322c7af558