### PR TITLE
Calcula total con cantidades y permite fallas temporales en cobro

### DIFF
--- a/src/main/java/com/tienda/pedidos/cobro/CobroService.java
+++ b/src/main/java/com/tienda/pedidos/cobro/CobroService.java
@@ -1,6 +1,7 @@
 package com.tienda.pedidos.cobro;
 
 import com.tienda.pedidos.pedido.Pedido;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -8,9 +9,21 @@ import java.math.BigDecimal;
 @Service
 public class CobroService {
 
+    private final boolean forzarFallaTemporal;
+
+    public CobroService(@Value("${cobro.forzar-falla-temporal:false}") boolean forzarFallaTemporal) {
+        this.forzarFallaTemporal = forzarFallaTemporal;
+    }
+
     public boolean process(Pedido pedido){
 
-        BigDecimal total = pedido.getProductos().stream().map(p -> p.getProducto().getPrecio()).reduce(BigDecimal.ZERO, BigDecimal::add);
+        if (forzarFallaTemporal) {
+            throw new RuntimeException("Falla temporal forzada");
+        }
+
+        BigDecimal total = pedido.getProductos().stream()
+                .map(p -> p.getProducto().getPrecio().multiply(BigDecimal.valueOf(p.getCantidad())))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
 
         int roundedValue = total.intValue();
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=pedidos
+cobro.forzar-falla-temporal=false


### PR DESCRIPTION
## Summary
- Multiplica precio por cantidad al calcular el total del cobro y mantiene la aprobación por paridad
- Permite forzar fallas temporales mediante el flag configurable `cobro.forzar-falla-temporal`

## Testing
- `mvn test` *(falló: Network is unreachable al resolver dependencias Maven)*

------
https://chatgpt.com/codex/tasks/task_e_68b456caa5f4832796f0c83d7c4b9786